### PR TITLE
Fixed formatting error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The PyPlot package also imports functions from Matplotlib's
 Unlike Matplotlib, however, you can create 3d plots directly without
 first creating an
 [Axes3d](http://matplotlib.org/dev/mpl_toolkits/mplot3d/api.html#axes3d)
-object, simply by calling one of: `bar3D, `contour3D`, `contourf3D`,
+object, simply by calling one of: `bar3D`, `contour3D`, `contourf3D`,
 `plot3D`, `plot_surface`, `plot_trisurf`, `plot_wireframe`, or
 `scatter3D` (as well as `text2D`, `text3D`), exactly like the
 correspondingly named methods of


### PR DESCRIPTION
The `3d Plotting` section formatting was mangled due to a missing back-tick.
