### PR TITLE
Added temporary functions for hist and xcorr by suffixing them with "_pyplot"

### DIFF
--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -275,6 +275,15 @@ addhelp("PyPlot.fill", py_fill)
 # no way to use method dispatch for hist or xcorr, since their
 # argument signatures look too much like Julia's
 
+# add temporary functions for hist and xcorr
+
+export hist_pyplot,xcorr_pyplot
+
+hist_pyplot(args...; kws...)=pycall(pltm["hist"], PyAny, args...; kws...)
+addhelp(:hist_pyplot, pltm["hist"])
+xcorr_pyplot(args...; kws...)=pycall(pltm["xcorr"], PyAny, args...; kws...)
+addhelp(:xcorr_pyplot, pltm["xcorr"])
+
 include("colormaps.jl")
 
 ###########################################################################


### PR DESCRIPTION
I am aware of your intention of keep this 1:1 with matplotlib. But I was in desperate need of the histogram plot, so I decided to implement it by suffix the function with "_pyplot" to avoid the clash.
