### PR TITLE
Better install instructions for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Alternatively, you can install the
 Otherwise, you can use the [Homebrew](http://brew.sh/) package manager:
 ```
 brew install python gcc freetype pyqt
-ln -s /usr/local/Cellar/freetype/2.5.3_1/include/freetype2/ /usr/local/include/freetype
+brew link --force freetype
 export PATH="/usr/local/bin:$PATH"
-export PYTHONPATH=/usr/local/lib/python2.7
+export PYTHONPATH="/usr/local/lib/python2.7:$PYTHONPATH"
 pip install numpy scipy matplotlib
 ```
 (You may want to add the two `export` commands to your `~/.profile` file so that they


### PR DESCRIPTION
These instructions should be equivalent, but play a little nicer with `brew` and if the user has already defined `$PYTHONPATH`