### PR TITLE
Allow selection of the Matplotlib backend using the MPLBACKEND enviro…

### DIFF
--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -140,7 +140,12 @@ function __init__()
         v"0.0" # fallback
     end
 
-    backend_gui = find_backend(matplotlib)
+    mpl_backend = haskey(ENV, "MPLBACKEND") ? ENV["MPLBACKEND"] : :none
+    if mpl_backend != :none
+        backend_gui = (mpl_backend, :none)
+    else
+        backend_gui = find_backend(matplotlib)
+    end
     # workaround JuliaLang/julia#8925
     global const backend = backend_gui[1]
     global const gui = backend_gui[2]
@@ -163,7 +168,9 @@ function __init__()
         Main.IJulia.push_posterror_hook(close_queued_figs)
     end
     
-    if isjulia_display[1]
+    if mpl_backend != :none
+        pltm[:switch_backend](mpl_backend)
+    elseif isjulia_display[1]
         if backend != "Agg"
             pltm[:switch_backend]("Agg")
         end


### PR DESCRIPTION
This patch allows setting the Matplotlib backend without changing the users' scripts or customizing default options (in .matplotlibrc). This feature is especially useful when mixing (existing) PyPlot calls with functions provided by the [GR framework](http://gr-framework.org/tutorials/matplotlib.html), a universal framework for cross-platform visualization applications.

A similar [pull request](https://github.com/matplotlib/matplotlib/pull/3710) (for Matplotlib) has already been accepted by the MPL developers. [Here](http://gr-framework.org/tutorials/mpl_interop.html) you can find a Python example which can easily be ported to Julia, providing enhanced features, especially for real-time visualization.

This is how a Julia example would look like:

    import PyCall
    @PyCall.pyimport numpy as np
 
    import PyPlot
    mpl = PyPlot
 
    import GR
 
    angles = np.load("700K_460.npy")
    lens = []
 
    for t in 1:100 
        mpl.cla()
        fig = mpl.subplot(211)
        mpl.ylim([0, 1000])
        mpl.hist(angles[t], 20, normed=0, facecolor="g", alpha=0.5)
        mpl.show()
 
        lens = [lens, np.size(angles[t])]
        if t > 1
            GR.setwindow(0, 10, 3500, 5000)
            GR.setviewport(0.1, 0.9, 0.05, 0.4)
            GR.axes(1, 0, 0, 3500, 2, 0, 0.005)
            GR.polyline(np.arange(t) / 10.0, lens)
        end
 
        GR.updatews()
    end