### PR TITLE
Improve Conda compatability

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ PyCall 1.0
 Colors
 LaTeXStrings
 Compat 0.4
+Conda 0.1.5

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,6 @@
+using PyCall
+import Conda
+# If Conda is used as python distribution then add matplotlib
+if PyCall.use_conda
+    Conda.add("matplotlib")
+end


### PR DESCRIPTION
If Conda is used as python distribution then matplotlib is going to be added automatically.
This requires https://github.com/stevengj/PyCall.jl/pull/191.