### PR TITLE
Don't try to re-setup any GUI event loop (for PyJulia)

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -70,6 +70,14 @@ function find_backend(matplotlib::PyObject)
 
     qt2gui = Dict("pyqt5"=>:qt_pyqt5, "pyqt4"=>:qt_pyqt4, "pyside"=>:qt_pyside)
 
+    if haskey(matplotlib, :pyplot)
+        # If matplotlib.pyplot exists, it means that matplotlib
+        # backend is already configured.  It may mean that PyPlot.jl
+        # is called via PyJulia.
+        backend = lowercase(matplotlib[:get_backend]())
+        return (backend, get(matplotlib2gui, backend, :none))
+    end
+
     rcParams = PyDict(matplotlib["rcParams"])
     default = lowercase(get(ENV, "MPLBACKEND",
                             getnone(rcParams, "backend", "none")))


### PR DESCRIPTION
If `matplotlib.pyplot` exists, it means that `matplotlib` backend is already configured.  It may mean that PyPlot.jl is called via PyJulia.  Don't setup any GUI event loop in this case since matplotlib does not support switching GUI backends.

With this patch, `%julia` magic can show interactive notebook plots:

![image](https://user-images.githubusercontent.com/29282/44889254-f1154480-ac89-11e8-8fb2-5aa433672bca.png)
