### PR TITLE
put reading the `__version__` from the pyplot package in try catch since it can fail

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -173,8 +173,7 @@ function __init__()
     isjulia_display[] = isdisplayok()
     copy!(matplotlib, pyimport_conda("matplotlib", "matplotlib"))
     global version = try
-        mvers = matplotlib.__version__
-        vparse(mvers)
+        vparse(matplotlib.__version__)
     catch
         v"0.0.0" # fallback
     end

--- a/src/init.jl
+++ b/src/init.jl
@@ -172,8 +172,8 @@ function __init__()
     ccall(:jl_generating_output, Cint, ()) == 1 && return nothing
     isjulia_display[] = isdisplayok()
     copy!(matplotlib, pyimport_conda("matplotlib", "matplotlib"))
-    mvers = matplotlib.__version__
     global version = try
+        mvers = matplotlib.__version__
         vparse(mvers)
     catch
         v"0.0.0" # fallback


### PR DESCRIPTION
We got a report saying `ERROR: InitError: KeyError: key :version not found`. This should work around it.