### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -73,7 +73,7 @@ convert(::Type{Figure}, o::PyObject) = Figure(o)
 ==(f::Figure, g::Figure) = PyObject(f) == PyObject(g)
 ==(f::Figure, g::PyObject) = PyObject(f) == g
 ==(f::PyObject, g::Figure) = f == PyObject(g)
-hash(f::Figure) = hash(PyObject(f))
+hash(f::Figure, h::UInt) = hash(PyObject(f), h)
 pycall(f::Figure, args...; kws...) = pycall(PyObject(f), args...; kws...)
 (f::Figure)(args...; kws...) = pycall(PyObject(f), PyAny, args...; kws...)
 Base.Docs.doc(f::Figure) = Base.Docs.doc(PyObject(f))

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -16,7 +16,7 @@ convert(::Type{ColorMap}, o::PyObject) = ColorMap(o)
 ==(c::ColorMap, g::ColorMap) = PyObject(c) == PyObject(g)
 ==(c::PyObject, g::ColorMap) = c == PyObject(g)
 ==(c::ColorMap, g::PyObject) = PyObject(c) == g
-hash(c::ColorMap) = hash(PyObject(c))
+hash(c::ColorMap, h::UInt) = hash(PyObject(c), h)
 pycall(c::ColorMap, args...; kws...) = pycall(PyObject(c), args...; kws...)
 (c::ColorMap)(args...; kws...) = pycall(PyObject(c), PyAny, args...; kws...)
 Base.Docs.doc(c::ColorMap) = Base.Docs.doc(PyObject(c))


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.